### PR TITLE
Correcting wget command for proxy configs (wrong directory)

### DIFF
--- a/WebServer.sh
+++ b/WebServer.sh
@@ -4,13 +4,13 @@
 # Install nginx
 /usr/bin/yum -y install nginx
 # Download the reverse proxy configuration
-/usr/bin/wget -O /etc/nginx/conf.d/proxy.conf https://raw.githubusercontent.com/sammcgeown/vRA-3-Tier-Application/master/app/proxy.nginx.conf
+/usr/bin/wget -O /etc/nginx/conf.d/proxy.conf https://raw.githubusercontent.com/sammcgeown/vRA-3-Tier-Application/master/config/proxy.nginx.conf
 /usr/bin/sed -i "s@SERVERNAME@$web_server_name@" /etc/nginx/conf.d/proxy.conf
 /usr/bin/sed -i "s@APPTIER@$app_server_name@" /etc/nginx/conf.d/proxy.conf
 # Create the SSL folder
 /usr/bin/mkdir /etc/nginx/ssl
 # Download the proxy SSL conf
-/usr/bin/wget -O /etc/nginx/ssl/proxy.conf https://raw.githubusercontent.com/sammcgeown/vRA-3-Tier-Application/master/app/proxy.ssl.conf
+/usr/bin/wget -O /etc/nginx/ssl/proxy.conf https://raw.githubusercontent.com/sammcgeown/vRA-3-Tier-Application/master/config/proxy.ssl.conf
 /usr/bin/sed -i "s@WEBSERVERNAME@$web_server_name@" /etc/nginx/ssl/proxy.conf
 # Generate SSL keys
 /usr/bin/openssl req -x509 -nodes -days 1825 -newkey rsa:2048 -keyout /etc/nginx/ssl/proxy.key -out /etc/nginx/ssl/proxy.pem -config /etc/nginx/ssl/proxy.conf


### PR DESCRIPTION
SSL generation fails, leading to SSL not functioning on the NGINX deployment. WGET is calling the wrong directory based on your git structure. Updated it to reflect the correct directory. 

Great work on this btw, going to be using it for a few TM related demos. Much appreciated. Going to look at ClarityUI'ifying it :) 